### PR TITLE
Bug correction in mult

### DIFF
--- a/sound4python.py
+++ b/sound4python.py
@@ -27,7 +27,7 @@ def sound(itr,samprate=16000,autoscale=True,output=False):
     #for now, assume 1-D iterable
     mult = 1
     if( autoscale ):
-        mult = 32768.0 / max(itr)
+        mult = 32767.0 / max(itr)
         #mult = 128.0 / max(itr)
 
     #create file in memory


### PR DESCRIPTION
Mult can be 32768, resulting in an overflow for int16 type which is an int between -32768 and 32767.

Changing in the line involving mult 32768 by 32767 solve this problem very easily, involving a very small loss of the amplitude precision.
